### PR TITLE
luci-app-samba4: Make checkbox 'Guests only' dependent on checkbox 'Allow guests'

### DIFF
--- a/applications/luci-app-samba4/htdocs/luci-static/resources/view/samba4.js
+++ b/applications/luci-app-samba4/htdocs/luci-static/resources/view/samba4.js
@@ -127,6 +127,7 @@ return view.extend({
 		o.enabled = 'yes';
 		o.disabled = 'no';
 		o.default = 'no';
+		o.depends('guest_ok', 'yes');
 
 		o = s.option(form.Flag, 'inherit_owner', _('Inherit owner'));
 		o.enabled = 'yes';


### PR DESCRIPTION
Allow only meaningful combinations of the checkboxes 'Guests only' and 'Allow guests'.